### PR TITLE
Orders via items

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -17,17 +17,19 @@ class OrdersController < ApplicationController
     session[:user_id] || not_found
     index_experiences
 
-    @user = User.find(session[:user_id].to_i) if @user_experience || @merch_experience
-    @user = User.find( params[:user_id].to_i) if @admin_merch_experience
-    @orders = Order.where(user_id: @user.id)  if @user
-    @orders = Order.all                       if @admin_experience
 
-    # binding.pry
+    @user = User.find(session[:user_id].to_i)    if @user_experience || @merch_experience
+    @user = User.find( params[:user_id].to_i)    if @admin_merch_experience
+    orders = @user.find_merchant_order_ids.uniq  if !@admin_experience && (@user && @user.role == 'merchant') && (@admin_merch_experience || @merch_experience)
+    @orders = Order.where(user_id: @user.id)     if @user
+    @orders = Order.where(id: orders)            if @user && orders
+    @orders = Order.all                          if @admin_experience
 
     if @merch_experience
-      items        = Item.where(user_id: @user.id).pluck(:id)
-      order_items  = OrderItem.where(item: items)
-      order_ids    = order_items.pluck(:order_id)
+      order_ids = @user.find_merchant_order_ids.uniq
+      # items        = Item.where(user_id: @user.id).pluck(:id)
+      # order_items  = OrderItem.where(item: items)
+      # order_ids    = order_items.pluck(:order_id)
       @orders      = Order.where(id: order_ids)
     end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -27,9 +27,6 @@ class OrdersController < ApplicationController
 
     if @merch_experience
       order_ids = @user.find_merchant_order_ids.uniq
-      # items        = Item.where(user_id: @user.id).pluck(:id)
-      # order_items  = OrderItem.where(item: items)
-      # order_ids    = order_items.pluck(:order_id)
       @orders      = Order.where(id: order_ids)
     end
 
@@ -50,7 +47,7 @@ class OrdersController < ApplicationController
   end
 
   def update
-    if request.path == fulfillment_path  && current_merchant?  # current_user.id == item.user_id ??
+    if request.path == fulfillment_path  && current_merchant? 
       fulfill_order
       redirect_to params[:previous]
     end
@@ -81,9 +78,6 @@ class OrdersController < ApplicationController
     items = OrderItem.where(order: order )
     finalize = items.all? { |item| item.status == 'complete' }
     (order.status = fulfilled; order.save) if finalize
-    # if finalize
-    #   (order.status = fulfilled; order.save)
-    # end
   end
 
   def cancel_order

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,24 +35,22 @@ class UsersController <ApplicationController
     else
       @user = User.find(current_user.id)
     end
-    # if !current_admin? ||
-      if params[:user]
-        @user.update(user_params)
-        flash[:success] = "You have successfully updated your info"
-        if current_admin? && @user.merchant?
-          redirect_to merchant_show_path(@user)
-        elsif current_admin?
-          redirect_to user_path(@user)
-        else
-          redirect_to profile_path
-        end
-      elsif request.path == login_path
-        flash[:notice] = "Please double check your info and try again"
-        redirect_back(fallback_location: root_path)
-      end
-    end
 
-  # end
+    if params[:user]
+      @user.update(user_params)
+      flash[:success] = "You have successfully updated your info"
+      if current_admin? && @user.merchant?
+        redirect_to merchant_show_path(@user)
+      elsif current_admin?
+        redirect_to user_path(@user)
+      else
+        redirect_to profile_path
+      end
+    elsif request.path == login_path
+      flash[:notice] = "Please double check your info and try again"
+      redirect_back(fallback_location: root_path)
+    end
+  end
 
   def show
     if request.path == profile_path

--- a/app/views/components/orders/_order_title.html.erb
+++ b/app/views/components/orders/_order_title.html.erb
@@ -3,16 +3,12 @@
   </h3>
 <!-- < % elsif @merch_experience || @admin_experience %> -->
 <% elsif @merch_experience %>
-  <!-- <h3>< %= link_to "Order: #{order.id}", order_path(order) %> -->
   <h3><%= link_to "Order: #{order.id}", dashboard_order_path(order) %>
   </h3>
-<!-- < % elsif @merch_order_experience %> -->
 <% elsif @merch_experience %>
-  <!-- <h3>< %= link_to "Order: #{order.id}", merchant_order_path(id: @user.id) %> -->
   <h3><%= link_to "Order: #{order.id}", merchant_order_path(user_id: @user.id, id: order.id) %>
   </h3>
 <% elsif @admin_merch_experience %>
-  <!-- <h3>< %= link_to "Order: #{order.id}", merchant_order_path(id: @user.id) %> -->
   <h3><%= link_to "Order: #{order.id}", merchant_order_path(user_id: @user.id, id: order.id) %>
   </h3>
 <% elsif @admin_experience && request.path != order_path(id: order.id) %>

--- a/spec/features/user_has_nav_bar_spec.rb
+++ b/spec/features/user_has_nav_bar_spec.rb
@@ -20,7 +20,6 @@ describe 'Navigation Bar:' do
       end
 
       it 'MERCHANTS link' do
-         #skip('MERCHANT PATH NEEDS GUTS')
         visit login_path
         click_on 'Merchants'
         expect(page).to have_current_path(merchants_path)
@@ -105,7 +104,6 @@ describe 'Navigation Bar:' do
       end
 
       it 'does have a dashboard' do
-         #skip('Dashboard Controller needs methods')
         click_on 'Dashboard'
         expect(page).to have_current_path(dashboard_path)
       end
@@ -124,22 +122,20 @@ describe 'Navigation Bar:' do
       end
 
       it 'does have a dashboard' do
-        #skip('Dashboard Controller needs methods')
         click_on 'Dashboard'
         expect(page).to have_current_path(dashboard_path)
       end
 
       it 'does have a users view' do
         expect(page).to have_content('Users')
-        #skip('Users Controller needs methods')
         click_on 'Users'
         expect(page).to have_current_path(users_path)
       end
 
       it 'does have an orders view' do
         expect(page).to have_content('Orders')
-        skip('needs Orders Controller')
-        click_on 'Orders'
+        # skip('needs Orders Controller')
+        click_on 'All Orders'
         expect(page).to have_current_path(orders_path)
       end
     end

--- a/spec/features/user_has_nav_bar_spec.rb
+++ b/spec/features/user_has_nav_bar_spec.rb
@@ -134,7 +134,6 @@ describe 'Navigation Bar:' do
 
       it 'does have an orders view' do
         expect(page).to have_content('Orders')
-        # skip('needs Orders Controller')
         click_on 'All Orders'
         expect(page).to have_current_path(orders_path)
       end


### PR DESCRIPTION
Order views, while visible sometimes, were actually always wrong for merchants (not user purchased orders) because the orders picked for display were actually the current_user's orders (---> why admin had no orders displayed while viewing a merchant's orders)

It's working correctly now, still needs better tests, and some previously skipped tests are now passing and working (nav bar).